### PR TITLE
Dfs/음료수 얼려 먹기

### DIFF
--- a/음료수_얼려_먹기.py
+++ b/음료수_얼려_먹기.py
@@ -1,0 +1,14 @@
+n, m = map(int, input().split())
+
+field = list()
+
+for _ in range(n):
+    field.append(list(map(int, input().split))[:m])
+
+
+def dfs(graph, start, visited):
+    visited[start] = True
+    
+    for i in graph[start]:
+        if not visited[i]:
+            return dfs(graph, i, visited)

--- a/음료수_얼려_먹기.py
+++ b/음료수_얼려_먹기.py
@@ -6,9 +6,28 @@ for _ in range(n):
     field.append(list(map(int, input().split))[:m])
 
 
-def dfs(graph, start, visited):
-    visited[start] = True
-    
-    for i in graph[start]:
-        if not visited[i]:
-            return dfs(graph, i, visited)
+# dfs로 특정한 노드를 방문한 뒤에 연결된 모든 노드들도 방문
+def dfs(x, y):
+    # 주어진 범위를 벗어나는 경우에는 즉시 종료
+    if x <= -1 or x >= n or y <= -1 or y >= m:
+        return False
+    # 현재 노드를 아직 방문하지 않았다면
+    if field[x][y] == 0:
+        # 해당 노드 방문 처리
+        # 상, 하, 좌, 우의 위치 모두 재귀적으로 호출
+        dfs(x - 1, y)
+        dfs(x, y - 1)
+        dfs(x + 1, y)
+        dfs(x, y + 1)
+        return True
+    return False
+
+# 모든 노드(위치)에 대하여 음료수 채우기
+result = 0
+for i in range(n):
+    for j in range(m):
+        # 현재 위치에서 DFS 수행
+        if dfs(i, j) == True:
+            result += 1
+
+print(result)


### PR DESCRIPTION
# 회고
- 0의 덩어리를 어떻게 하면 카운팅할 수 있을지 고민하다가 시간 초과
  - 0을 그대로 둘 경우 서치하는 도중에 중복될 것을 우려
- 풀이의 경우에는 dfs를 통해서 이미 서치된 경우 1로 바꿔서 중복 서치를 방지
- dfs를 동서남북으로 서치함
- 2차원 배열의 경우 dfs()를 4번 반복하여 문제 푸는 방식을 고려해야겠다.

# DFS/BFS
- 탐색 -> 원하는 데이터를 찾는 과정
- 자료구조 -> 데이터를 관리하고 처리하기 위한 구조
- 스택 `list()`의 `append()`와 `pop()`을 활용
- 큐 `from collections import deque`의 `append()` 와 `popleft()`를 활용
  - deque([])와 같이 이터러블한 객체로 초기화
    - deque(2)와 같이 int형을 넣으면 에러 반환
  - list(deque)를 통해서 list()로 변환 가능
- 재귀함수 
  - 종료 조건을 항상 명시해줘야함
  - 컴퓨터 내부에서는 스택을 활용 -> 스택 자료구조와 같다고 볼 수 있음
- 재귀 vs for 문
  - 재귀의 경우가 더 간결 -> 점화식을 활용하기 때문, 점화식은 추후 다이나믹 프로그래밍에서 활용
- 인접행렬 -> 2차원 배열로 그래프를 표현 -> 연결되지 않은 노드는 `INF`로 표현 -> 모든 관계를 저장하기 때문에 공간 복잡도가 증가
- 인접 리스트 -> 리스트로 그래프의 연결 관계를 표현 -> 연결된 데이터를 하나씩 확인하기 때문에 시간 복잡도가 증가
- 재귀로 DFS를 작성하면 시간이 오래 걸릴 수 있다.
- 코테에서 2차원 배열 탐색 문제를 보면 그래프 형태로 표현한 다음 풀이 방법을 고민해 보는 것도 좋다.