### PR TITLE
Graph/팀_결성

### DIFF
--- a/팀_결성.py
+++ b/팀_결성.py
@@ -1,0 +1,35 @@
+def find_parent(parent, x):
+    if parent[x] != x:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+
+def union_parent(parent, a, b):
+    a = find_parent(parent, a)
+    b = find_parent(parent, b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+
+v, e = map(int, input().split())
+
+parent = [0] * (v + 1)
+for i in range(0, v + 1):
+    parent[i] = i
+
+result = list()
+
+for _ in range(e):
+    a, x, y = map(int, input().split())
+    if a == 0:
+        union_parent(parent, x, y)
+    elif a == 1:
+        result.append(find_parent(parent, x) == find_parent(parent, y))
+
+for i in result:
+    if i:
+        print("YES")
+    else:
+        print("NO")


### PR DESCRIPTION
# 회고
- 빠르게 풀려다 보니 문법쪽에서 실수가 많이 나온다
  - 실수를 바로잡기 위해서는 코드를 하나하나 다 읽어야 하는데 이 과정에서 많은 시간을 소모하게 됨
  - 처음부터 제대로 코드를 짜나가자
# 그래프
## 서로소 집합 자료구조
- 서로소 집합이란 공통 원소가 없는 두 집합을 의미
- 서로소 부분 집합들로 나눠진 원소들의 데이터를 처리하기 위한 자료
- `union()`과 `find()`를 사용하여 unio-find 자료구조라고도 불림
  - `union()` : 두 개 이상의 원소를 하나의 집합으로 만듦
  - `find()` : 특정한 원소가 속한 집합을 알려줌
- 각 집합이 어느 원소를 공통으로 가지고 있는지 확인 가능
- 트리 자료 구조를 이용하여 집합을 표현한다.
- 서로소 집합 계산 알고리즘
  1. `union()` 연산을 확인하여, 서로 연결된 두 노드 A, B 확인
      1.  A, B의 루트 노드 A`와 B`를 찾는다.
      2. A`를 B`의 부모 노드로 설정
  2. 모든 `union`이 완료 될 때까지 1을 반복
- 경로 단축을 통해 `find()`의 시간 복잡도를 감소 시킬 수 있다.
  - 루트 노드가 바로 부모 노드가 되기 때문
- 사이클 판별
  - 무방향 그래프 내에서만 가능
  1. 각 간선을 확인하면서 두 노드의 루트 노드를 확인
      1. 루트 노드가 서로 다르다면 두 노드에 대해 `union()` 실행
      2. 루트 노드가 서로 같다면 cycle이 발생한 것
  2. 모든 간선에 대해 1을 반복
## 신장 트리
- 하나의 그래프가 있을 때 모든 노드를 포함하면서 사이클이 존재하지 않는 부분 그래프
  - cycle이 될 법한 간선을 제외
## 크루스칼 알고리즘
- 최소 비용으로 만들 수 있는 신장 트리를 찾는 알고리즘을 최소 신장 알고리즘이라고 하고 이 중 하나가 크루스칼
1. 간선 데이터를 비용에 따라 오름차순 정렬
2. 간선을 하나씩 확인하면서 cycle을 발생시키는지 확인
    1. cycle이 없는 경우, 최소 신장 트리에 포함
    2. cycle이 있는 경우, 최소 신장 트리에서 제외
3. 모든 간선에 대해 2번을 반복한다.
- 최종적으로 신장 트리에 포함되는 간선의 개수는 `노드의 개수 - 1`
- 시간 복잡도는 O(ElogE)
## 위상 정렬
- 방향 그래프의 모든 노드를 방향성에 거스르지 않도록 순서대로 나열하는 것
- 진입 차수 : 특정한 노드로 들어오는 간선의 개수
1. 진입 차수가 0인 노드를 큐에 넣는다
2. 큐가 빌 때까지 반복
    1. 큐에서 원소를 꺼내 해당 노드에서 출발하는 간선을 그래프에서 제거
    2. 새롭게 진입차수가 0이된 노드를 큐에 넣는다
- 큐에서 원소가 V번 적출되기 전에 비어버리면 사이클이 발생한 것
  - 사이클에 포함된 원소는 큐에 들어가지 못하기 때문
- 시간 복잡도 : O(V + E)