### PR TITLE
작업

### DIFF
--- a/작업.py
+++ b/작업.py
@@ -1,0 +1,22 @@
+import sys
+sys.setrecursionlimit(10**5)
+
+def dfs(v, visited):
+    visited[v] = True
+    cnt = 0
+    for i in graph[v]:
+        if not visited[i]:
+            cnt += dfs(i, visited)
+    return cnt + 1
+
+n, m = map(int, input().split())
+graph = [[] for _ in range(n + 1)]
+
+for _ in range(m):
+    a, b = map(int, input().split())
+    graph[b].append(a)
+    
+x = int(input())
+visited = [False] * (n + 1)
+
+print(dfs(x, visited) - 1)


### PR DESCRIPTION
# 회고
- `sys.setrecursionlimit()` 의 설정을 무조건 크게할 경우 메모리 초과가 발생
- node의 수를 보고 적당하게 잡아주는 것이 중요