### PR TITLE
배

### DIFF
--- a/배.py
+++ b/배.py
@@ -1,0 +1,30 @@
+import heapq
+
+n = int(input())
+weights = list(map(int, input().split()))
+m = int(input())
+boxes = list(map(int, input().split()))
+
+if max(weights) < max(boxes):
+    print(-1)
+    exit()
+
+boxes = [-i for i in boxes]
+
+weights.sort(reverse=True)
+
+result = 0
+while boxes:
+    tmp = []
+    for w in weights:
+        if not boxes:
+            break
+        tmp_box = -heapq.heappop(boxes)
+        while tmp_box > w and boxes:
+            tmp.append(-tmp_box)
+            tmp_box = -heapq.heappop(boxes)
+    for t in tmp:
+        heapq.heappush(boxes, t)
+    result += 1
+
+print(result)

--- a/배.py
+++ b/배.py
@@ -1,30 +1,25 @@
-import heapq
-
 n = int(input())
-weights = list(map(int, input().split()))
+cranes = list(map(int, input().split()))
 m = int(input())
 boxes = list(map(int, input().split()))
 
-if max(weights) < max(boxes):
+if max(cranes) < max(boxes):
     print(-1)
     exit()
 
-boxes = [-i for i in boxes]
-
-weights.sort(reverse=True)
+# 크레인, 박스 모두 내림차순 정렬
+cranes.sort(reverse=True)
+boxes.sort(reverse=True)
 
 result = 0
+# 모든 박스가 옮겨질 때까지 반복
 while boxes:
-    tmp = []
-    for w in weights:
-        if not boxes:
-            break
-        tmp_box = -heapq.heappop(boxes)
-        while tmp_box > w and boxes:
-            tmp.append(-tmp_box)
-            tmp_box = -heapq.heappop(boxes)
-    for t in tmp:
-        heapq.heappush(boxes, t)
+    for crane in cranes:
+        # 현재 크레인으로 옮길 수 있는 가장 무거운 박스를 찾으면 바로 제거
+        for i in range(len(boxes)):
+            if boxes[i] <= crane:
+                boxes.pop(i)
+                break
     result += 1
-
+    
 print(result)


### PR DESCRIPTION
# 회고
- heapq를 활용
  - 무게가 맞지 않는 상자를 저장하기 위한 `tmp[]` 배열로 인한 공간 복잡도 증가
  - `tmp[]` 배열을 다시 `boxes`에 저장하기 위한 시간 복잡도 증가
  - `boxes`에 추가하고 다시 `heapq`를 활용해 꺼내는 과정을 반복할거면 그냥 리스트의 전체를 순회하는 것이 더 낫다