### PR TITLE
연속 합

### DIFF
--- a/연속_합.py
+++ b/연속_합.py
@@ -1,16 +1,7 @@
-from itertools import combinations
-
 n = int(input())
 array = list(map(int, input().split()))
 
-dp = []
-dp.append(array[0])
 for i in range(1, n):
-    s = dp[i - 1] + array[i]
-    dp.append(s)
-
-result =  -int(1e9)
-for a, b in list(combinations(dp, 2)):
-    result = max(result, b - a)
-
-print(result)
+    array[i] = max(array[i - 1] + array[i], array[i])
+    
+print(max(array))

--- a/연속_합.py
+++ b/연속_합.py
@@ -1,0 +1,16 @@
+from itertools import combinations
+
+n = int(input())
+array = list(map(int, input().split()))
+
+dp = []
+dp.append(array[0])
+for i in range(1, n):
+    s = dp[i - 1] + array[i]
+    dp.append(s)
+
+result =  -int(1e9)
+for a, b in list(combinations(dp, 2)):
+    result = max(result, b - a)
+
+print(result)


### PR DESCRIPTION
# 회고
- Kadane 알고리즘을 통해서 풀어야 하는 문제
- Kadane 알고리즘이란?
  - 주어진 배열에서 연속된 원소들의 부분합 중 최댓값을 효율적으로 찾는 알고리즘
  - 시간 복잡도 O(n)
```
    for i in range(1, n):
        dp[i] = max(dp[i - 1] + array[i], array[i])
```
  - `dp[i]`는 i번째 원소를 반드시 포함하는 연속 부분합의 최댓값
  - `dp[i - 1] + array[i]` 
    - 이전까지의 최댓값에 현재 원소를 더해 연속된 부분합을 확장
  - `array[i]`
    - 이전까지의 연속 부분합을 버리고, 현재 원소에서 새롭게 시작
    - 이전까지의 합이 음수라면, 현재 원소 하나만 포함하는 것이 더 큰 값을 만들기 때문