### PR TITLE
ACM_Craft

### DIFF
--- a/ACM_Craft.py
+++ b/ACM_Craft.py
@@ -1,0 +1,30 @@
+from collections import deque
+
+for tc in range(int(input())):
+    n, k = map(int, input().split())  # 건물의 수, 건설 규칙
+    graph = [[] for _ in range(n + 1)]
+    cost = list(map(int, input().split()))
+    cost = [0] + cost
+    indegree = [0] * (n + 1)
+    for _ in range(k):
+        a, b = map(int, input().split())
+        graph[a].append(b)
+        indegree[b] += 1
+
+    w = int(input()) # 승리하기 위해 건설해야 하는 번호 
+    q = deque()
+    result = [0] * (n + 1)
+    for i in range(1, n + 1):
+        if indegree[i] == 0:
+            q.append(i)
+            result[i] = cost[i]
+
+    while q:
+        v = q.popleft()
+        for i in graph[v]:
+            indegree[i] -= 1
+            result[i] = max(result[i], result[v] + cost[i])
+            if indegree[i] == 0:
+                q.append(i)
+                
+    print(result[w])


### PR DESCRIPTION
# 회고
- 진입 차수가 높은 건물을 짓기 위해서는 진입하려는 노드의 건물들이 모두 지어져 있어야 함
  - 진입하려는 노드는 모두 동시에 짓기 시작 -> 제일 시간이 오래 걸리는 건물을 기준으로 계산해야함
  - `result[i] = max(result[i], result[v] + cost[i])` 를 활용
    - `max()`를 통해 계속해서 비교하여 시간이 제일 오래 걸리는 차수를 기준으로 계산