### PR TITLE
SQL/6번

### DIFF
--- a/SQL/01_06.sql
+++ b/SQL/01_06.sql
@@ -83,3 +83,12 @@ SELECT c.name, COUNT(e.employee_id), AVG(a.pay)
         AND e.employee_id = a.employee_id
     GROUP BY c.name
     ORDER BY c.name;
+
+# 문제 6
+SELECT e.name, c.company_id, a.pay
+    FROM employee AS e, company AS c, affiliation AS a
+    WHERE e.employee_id = a.employee_id
+        AND a.company_id = c.company_id
+    GROUP BY c.company_id
+        HAVING AVG(a.pay) < a.pay
+    ORDER BY e.name;

--- a/SQL/01_06.sql
+++ b/SQL/01_06.sql
@@ -86,9 +86,13 @@ SELECT c.name, COUNT(e.employee_id), AVG(a.pay)
 
 # 문제 6
 SELECT e.name, c.company_id, a.pay
-    FROM employee AS e, company AS c, affiliation AS a
+    FROM employee AS e, affiliation AS a,
+         (
+             SELECT temp.company_id as company_id, AVG(temp.pay) AS avg_pay
+                FROM affiliation AS temp
+                GROUP BY temp.company_id
+         ) AS c
     WHERE e.employee_id = a.employee_id
         AND a.company_id = c.company_id
-    GROUP BY c.company_id
-        HAVING AVG(a.pay) < a.pay
+        AND a.pay > c.avg_pay
     ORDER BY e.name;


### PR DESCRIPTION
# 회고
- 회사 평균 급여보다 높은 사람을 찾는 문제
- `GROUP BY`를 통해서 회사를 묶는 경우
  - `e.name`과 `a.pay`가 `GROUP BY`에 속하지 않아 DBMS에서 오류 발생
    - `HAVING` 절은 `GROUP BY`로 나뉘어진 임시 테이블들이 합쳐진 후, 집계 값이 지정된 조건을 충족하는 행만 반환하도록 함
- 풀이는 서브 쿼리를 활용
  - 서브 쿼리를 통해서 각 회사별 평균 임금을 계산
  - WHERE을 통해서 비교해 나감