### PR TITLE
양과_늑대

### DIFF
--- a/양과_늑대.py
+++ b/양과_늑대.py
@@ -1,0 +1,24 @@
+def solution(info, edges):
+    visited = [False] * len(info)
+    answer = []
+
+    def dfs(sheep, wolf):
+        if sheep > wolf:
+            answer.append(sheep)
+        else:
+            return
+
+        for p, c in edges:
+            if visited[p] and not visited[c]:
+                visited[c] = True
+                if info[c] == 0:
+                    dfs(sheep + 1, wolf)
+                else:
+                    dfs(sheep, wolf + 1)
+                visited[c] = False
+
+    # 루트 노드부터 시작
+    visited[0] = 1
+    dfs(1, 0)
+
+    return max(answer)


### PR DESCRIPTION
# 회고
- DFS를 활용하여 리프 노드에 도달했을 때부터 양과 늑대를 더해나가는 방식
  - 요구사항에 맞춰서 루트에서 내려가는 도중 늑대가 더 많은 경우를 고려할 수 없음
- BFS를 활용하여 내려가는 경우
  - 먼저 간 경로에 따라서 결과가 다르게 나올 수 있다
- 풀이
  - DFS로 내려가면서 양이 더 큰 경우를 배열에 저장하여, 배열에서 제일 큰 값을 반환
  - 늑대가 더 많으면 `return`