### PR TITLE
완전범죄

### DIFF
--- a/완전범죄.py
+++ b/완전범죄.py
@@ -5,14 +5,17 @@ INF = int(1e9)
 def solution(info, n, m):
     answer = 0
     
+    dp = [[INF] * 121 for _ in range(121)]
     def back_traking(a, b, i):
         if a >= n or b >= m:
             return INF
         if i == len(info):
             return a
-
         
-        return min(back_traking(a + info[i][0], b, i + 1), back_traking(a, b + info[i][1], i + 1))
+        if dp[a][b] >= INF:
+            dp[a][b] = min(back_traking(a + info[i][0], b, i + 1), 
+                            back_traking(a, b + info[i][1], i + 1))
+        return dp[a][b]
     
     answer = back_traking(0, 0, 0)
     if answer >= INF:

--- a/완전범죄.py
+++ b/완전범죄.py
@@ -1,18 +1,21 @@
 # [i][0] A도둑, [i][1] B도둑, A 최소 흔적, B 최소 흔적
+
+INF = int(1e9)
+
 def solution(info, n, m):
     answer = 0
-    # B 도둑을 기준으로 그리드로 풀이
-    info.sort(key=lambda x: (x[1], x[0]))
+    
+    def back_traking(a, b, i):
+        if a >= n or b >= m:
+            return INF
+        if i == len(info):
+            return a
 
-    a = n
-    b = m
-    for i, inf in enumerate(info):
-        if inf[1] < b:
-            b -= inf[1]
-        elif inf[0] < a:
-            a -= inf[0]
-            answer += inf[0]
-        else:
-            return -1
-
+        
+        return min(back_traking(a + info[i][0], b, i + 1), back_traking(a, b + info[i][1], i + 1))
+    
+    answer = back_traking(0, 0, 0)
+    if answer >= INF:
+        return -1
+        
     return answer

--- a/완전범죄.py
+++ b/완전범죄.py
@@ -1,0 +1,18 @@
+# [i][0] A도둑, [i][1] B도둑, A 최소 흔적, B 최소 흔적
+def solution(info, n, m):
+    answer = 0
+    # B 도둑을 기준으로 그리드로 풀이
+    info.sort(key=lambda x: (x[1], x[0]))
+
+    a = n
+    b = m
+    for i, inf in enumerate(info):
+        if inf[1] < b:
+            b -= inf[1]
+        elif inf[0] < a:
+            a -= inf[0]
+            answer += inf[0]
+        else:
+            return -1
+
+    return answer

--- a/완전범죄.py
+++ b/완전범죄.py
@@ -2,23 +2,29 @@
 
 INF = int(1e9)
 
+
 def solution(info, n, m):
     answer = 0
-    
-    dp = [[INF] * 121 for _ in range(121)]
+
+    dp = {}  # (i, a, b)를 키로 하는 메모제이션(dict())
+
     def back_traking(a, b, i):
         if a >= n or b >= m:
             return INF
         if i == len(info):
             return a
-        
-        if dp[a][b] >= INF:
-            dp[a][b] = min(back_traking(a + info[i][0], b, i + 1), 
-                            back_traking(a, b + info[i][1], i + 1))
-        return dp[a][b]
-    
+        if (i, a, b) in dp:
+            return dp[(i, a, b)]
+
+        mv = min(
+            back_traking(a + info[i][0], b, i + 1),
+            back_traking(a, b + info[i][1], i + 1),
+        )
+        dp[(i, a, b)] = mv
+        return mv
+
     answer = back_traking(0, 0, 0)
     if answer >= INF:
         return -1
-        
+
     return answer


### PR DESCRIPTION
# 회고
- 그리드로 풀이
  - 풀이 중간에 a가 더 많이 훔쳤을 경우의 수를 고려하지 못하여 최적의 해를 구할 수 없음
- 백트래킹으로 풀이
  - 테스트 케이스는 통과하나, 시간초과가 발생
- 백트래킹 + dp로 풀이
  - dp를 활용한 메모제이션
  - `dp[a][b]`로 풀이
    - 현재 몇 번째 인덱스인지 고려를 못함
      - 2번째 인덱스의 a, b인지 1번째 인덱스의 a, b인지 dp는 알 수 없음
- 풀이
  - 백트래킹 + dp로 풀이하지만 현재 a, b, i 값을 고려하여 풀이
```
dp = {} # 딕셔너리 key는 (현재 인덱스, a, b)
```