### PR TITLE
충돌위험_찾기

### DIFF
--- a/충돌위험_찾기.py
+++ b/충돌위험_찾기.py
@@ -1,0 +1,43 @@
+from collections import Counter
+
+
+def solution(points, routes):
+    def bfs(route):
+        idx = 0
+        pa = []
+        for i in range(len(route) - 1):
+            sx, sy = spots[route[i] - 1]
+            ex, ey = spots[route[i + 1] - 1]
+
+            # x 좌표 맞추기
+            while sx != ex:
+                pa.append((sx, sy, idx))
+                if sx < ex:
+                    sx += 1
+                else:
+                    sx -= 1
+                idx += 1
+
+            # y 좌표 맞추기
+            while sy != ey:
+                pa.append((sx, sy, idx))
+                if sy < ey:
+                    sy += 1
+                else:
+                    sy -= 1
+                idx += 1
+        pa.append((sx, sy, idx))
+        return pa
+
+    spots = [i for i in points]
+    second = []
+
+    for route in routes:
+        second.extend(bfs(route))
+    res = 0
+    temp = Counter(second)
+    for i in temp.values():
+        if i >= 2:
+            res += 1
+
+    return res


### PR DESCRIPTION
# 회고
- bfs까지 활용할 필요가 없는 문제
- x좌표를 우선시 하기 때문에 목표지와 x좌표를 먼저 맞춘 후, y좌표를 맞추면 됨
- 각 로봇의 좌표와 횟수를 포함한 이동 경로를 list에 저장
- Counter를 활용하여 같은 좌표와 같은 인덱스가 2 이상인 요소가 존재한다면 이는 충돌할 가능성이 있다는 것을 의미
```
from collections import Counter # 딕셔너리 형태로 반환

Counter().elements() # 요소를 반환
```
- Counter는 `set`과 마찬가지로 공집합, 합집합, 차집합이 가능 
  - 이를 활용하여 중복된 값을 가진 집합의 공집합이 가능
  - elements()
    - 카운트가 1보다 큰 각 요소를, 그 값만큼 반복하여 반환하는 iterator를 제공
  - most_common([n])
    - 가장 빈도수가 높은 항목들을 내림차순으로 정렬하여 반환.
    - 인자 n을 지정하면 상위 n개의 (요소, 카운트) 튜플 목록을 반환하며, 인자를 생략하거나 None을 전달하면 모든 항목을 빈도순으로 반환