### PR TITLE
민서의_응급_수술

### DIFF
--- a/민서의_응급_수술.py
+++ b/민서의_응급_수술.py
@@ -1,0 +1,35 @@
+import sys
+input = sys.stdin.readline
+
+def find_parent(parent, x):
+    if x != parent[x]:
+        parent[x] = find_parent(parent, parent[x])
+    return parent[x]
+
+def union_parent(parent, a, b):
+    a = find_parent(parent, a)
+    b = find_parent(parent, b)
+    if a < b:
+        parent[b] = a
+    else:
+        parent[a] = b
+
+n, m = map(int, input().split())
+parent = list(range(n + 1))
+
+result = 0
+for i in range(m):
+    a, b = map(int, input().split())
+    if find_parent(parent, a) != find_parent(parent, b):
+        union_parent(parent, a, b)
+    else:
+        result += 1
+
+for i in range(1, n + 1):
+    find_parent(parent, i)
+
+parent = set(parent)
+parent.remove(0)
+
+# 연결 해야하는 경우의 수
+print(result + len(parent) - 1)


### PR DESCRIPTION
# 회고
- 크루스칼 알고리즘을 활용
  - 순환이 존재하는 경로일 경우 연결하지 않고 result += 1을 통해서 선을 제거하는 연산을 카운팅
  - 추후 parent의 부모 수를 활용하여 필요한 간선을 구함
```
for i in range(1, n + 1):
    find_parent(parent, i)
```
- 을 통해서 부모 노드의 값을 최신화할 필요가 있음 -> union 과정에서 최신화가 안되기 때문