### PR TITLE
Sql/leet code1934

### DIFF
--- a/SQL/LeetCode1934.sql
+++ b/SQL/LeetCode1934.sql
@@ -1,7 +1,5 @@
-SELECT DISTINCT A.user_id AS user_id, IF(B.rate IS NULL, 0, B.rate) AS confirmation_rate
+SELECT DISTINCT A.user_id, ROUND(AVG(IF(B.action = 'confirmed', 1, 0)), 2) AS confirmation_rate
 FROM Signups AS A
-         LEFT JOIN
-     (SELECT user_id, ROUND(SUM(action LIKE 'confirmed') / COUNT(*), 2) AS rate
-      FROM Confirmations
-      GROUP BY user_id) AS B
-     ON A.user_id = B.user_id
+         LEFT JOIN Confirmations AS B
+                   ON A.user_id = B.user_id
+GROUP BY A.user_id;

--- a/SQL/LeetCode1934.sql
+++ b/SQL/LeetCode1934.sql
@@ -1,0 +1,7 @@
+SELECT DISTINCT A.user_id AS user_id, IF(B.rate IS NULL, 0, B.rate) AS confirmation_rate
+FROM Signups AS A
+         LEFT JOIN
+     (SELECT user_id, ROUND(SUM(action LIKE 'confirmed') / COUNT(*), 2) AS rate
+      FROM Confirmations
+      GROUP BY user_id) AS B
+     ON A.user_id = B.user_id


### PR DESCRIPTION
# 회고
- 특정 조건에 대한 카운팅을 하고 싶을 때는 `SUM(조건문)`을 활용하는 것이 좋다.
  - 조건문이 참이면 1, 아니면 0을 반환하기 때문에 특정 조건에 대한 카운팅을 진행한다.
## 풀이
- 서브쿼리로 완성시킨 다음에 JOIN하는 것보다 JOIN을 진행한 후 GROUP BY를 하는 것이 더욱 효율적
- `AVG(SUM(조건문))`은 말도 안되는 문법이다.
- `AVG(IF(조건문, 1, 0))`을 활용하도록 하자