### PR TITLE
Sql/leet code1907

### DIFF
--- a/SQL/LeetCode1907.sql
+++ b/SQL/LeetCode1907.sql
@@ -1,0 +1,9 @@
+SELECT
+    CASE
+        WHEN income > 50000 THEN 'High Salary'
+        WHEN income >= 20000 THEN 'Average Salary'
+        ELSE 'Low Salary'
+        END AS category
+     ,COUNT(*) AS accounts_count
+FROM Accounts
+GROUP BY Category

--- a/SQL/LeetCode1907.sql
+++ b/SQL/LeetCode1907.sql
@@ -1,9 +1,5 @@
-SELECT
-    CASE
-        WHEN income > 50000 THEN 'High Salary'
-        WHEN income >= 20000 THEN 'Average Salary'
-        ELSE 'Low Salary'
-        END AS category
-     ,COUNT(*) AS accounts_count
-FROM Accounts
-GROUP BY Category
+SELECT 'High Salary' AS category, SUM(income > 50000) AS accounts_count FROM Accounts
+UNION ALL
+SELECT 'Average Salary' AS category, SUM(income BETWEEN 20000 AND 50000) AS accounts_count FROM Accounts
+UNION ALL
+SELECT 'Low Salary' AS category, SUM(income < 20000) AS accounts_count FROM Accounts


### PR DESCRIPTION
# 회고
https://leetcode.com/problems/count-salary-categories/description/
## 내 풀이
- `CASE`문을 활용 -> 카테고리중에 `COUNT`가 잡히지 않는 경우 표시가 안되기 떄문에 틀림
## 풀이
- `UNION`을  활용하여 풀이
- 숫자의 경우 `SET`을 활용하는 풀이를 사용했지만, 문자열을 활용하는 경우는 처음 본 케이스
## `UNION` VS `UNION ALL`
- `UNION`의 경우 중복을 제거하기 떄문에 더 많은 시간을 소요
- `UNION ALL`은 중복을 제거하지 않기 때문에 적은 시간을 소요