### PR TITLE
SQL/Leet code176

### DIFF
--- a/SQL/LeetCode176.sql
+++ b/SQL/LeetCode176.sql
@@ -1,0 +1,4 @@
+SELECT DISTINCT salary
+FROM Employee
+ORDER BY salary DESC LIMIT 1
+OFFSET 1

--- a/SQL/LeetCode176.sql
+++ b/SQL/LeetCode176.sql
@@ -1,4 +1,5 @@
-SELECT DISTINCT salary
-FROM Employee
-ORDER BY salary DESC LIMIT 1
-OFFSET 1
+SELECT
+    (SELECT DISTINCT salary
+     FROM Employee
+     ORDER BY salary DESC
+        LIMIT 1 OFFSET 1) AS SecondHighestSalary

--- a/SQL/LeetCode176.sql
+++ b/SQL/LeetCode176.sql
@@ -1,5 +1,3 @@
-SELECT
-    (SELECT DISTINCT salary
-     FROM Employee
-     ORDER BY salary DESC
-        LIMIT 1 OFFSET 1) AS SecondHighestSalary
+SELECT MAX(salary) AS SecondHighestSalary
+FROM Employee
+WHERE salary < (SELECT MAX(salary) FROM Employee);


### PR DESCRIPTION
# 회고
https://leetcode.com/problems/second-highest-salary/description/
## 내 풀이
- `OFFSET`을 활용했기 때문에, 테이블의 크기가 작을 경우 null값을 표시하는 것이 아닌 빈 값이 표현
## 풀이 1
- `SELECT` 쿼리로 한 번 더 감싼다 -> 값이 없는 경우 NULL로 표기된다.
## 풀이 2
- 두 번째로 큰 값을 찾는 것이 문제
-  `WHERE`문에 현재 테이블에서 제일 큰 급여를 제외한 나머지를 조건으로 사용
- 조건을 통해 걸러진 테이블 중 제일 큰 값을 가져온다.