### PR TITLE
Sql/leet code185

### DIFF
--- a/SQL/LeetCode185.sql
+++ b/SQL/LeetCode185.sql
@@ -1,7 +1,12 @@
-SELECT B.name AS Department, A.name AS Employee, A.salary AS Salary
-FROM Employee AS A JOIN Department AS B ON A.departmentId = B.id
-WHERE (A.departmentId, A.salary) IN (SELECT departmentId, salary
-                                     FROM Employee
-                                     WHERE A.departmentId = departmentId
-                                     ORDER BY salary DESC
-                                     LIMIT 3);
+WITH RankedSalaries AS (
+    SELECT
+        e.name AS Employee,
+        e.salary AS Salary,
+        d.name AS Department,
+        DENSE_RANK() OVER (PARTITION BY e.departmentId ORDER BY e.salary DESC) AS rnk
+    FROM Employee e
+             JOIN Department d ON e.departmentId = d.id
+)
+SELECT Department, Employee, Salary
+FROM RankedSalaries
+WHERE rnk <= 3;

--- a/SQL/LeetCode185.sql
+++ b/SQL/LeetCode185.sql
@@ -1,0 +1,7 @@
+SELECT B.name AS Department, A.name AS Employee, A.salary AS Salary
+FROM Employee AS A JOIN Department AS B ON A.departmentId = B.id
+WHERE (A.departmentId, A.salary) IN (SELECT departmentId, salary
+                                     FROM Employee
+                                     WHERE A.departmentId = departmentId
+                                     ORDER BY salary DESC
+                                     LIMIT 3);


### PR DESCRIPTION
# 회고
https://leetcode.com/problems/department-top-three-salaries/
# 내 풀이
- 서브쿼리에 `LIMIT`를 사용하여 풀이 -> 문법 오류가 발생
  - MySQL은 서브쿼리함수가 사용되는 서브쿼리에 `LIMIT`를 지원하지 않음
# 풀이
- `WITH` -> 공통 테이블 표현식
  - 쿼리 내에 임시적으로 이름이 지정된 결과 집합을 생성
```
WITH {테이블명} AS (
 {SELECT 문}
)
```
```
WITH RECURSIVE EmployeeHierarchy AS (
    SELECT id, name, managerId
    FROM Employee
    WHERE managerId IS NULL -- 최고 관리자 찾기

    UNION ALL

    SELECT e.id, e.name, e.managerId
    FROM Employee e
    JOIN EmployeeHierarchy eh ON e.managerId = eh.id -- 하위 직원 찾기
)
SELECT *
FROM EmployeeHierarchy;
```
  - 재귀 처리할 때 유용
- `PARTITON BY`를 활용 
  - 데이터를 특정 기준에 따라 그룹화하여 각 그룹 내에서 계산을 수행
  - `GROUP BY`와 다르게 데이터를 집계하지 않고 원래 행을 유지하면서 그룹별로 계산을 수행
```
DENSE_RANK() OVER (PARTITION BY e.departmentId ORDER BY e.salary DESC) AS rnk
```
  - `PARTITON BY`로 지정된 곳에서만 랭크를 부여